### PR TITLE
fix: use @vercel/analytics/next import for Next.js (activates Vercel Analytics dashboard)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata, Viewport } from 'next'
 import { DM_Sans } from 'next/font/google'
-import { Analytics } from '@vercel/analytics/react'
+import { Analytics } from '@vercel/analytics/next'
 import './globals.css'
 import { SITE_URL } from '@/lib/config'
 


### PR DESCRIPTION
## What
Updates the Analytics import from `@vercel/analytics/react` to `@vercel/analytics/next`.

## Why
Vercel now recommends the `/next` path for Next.js projects — this is the optimized entrypoint and is required for the Vercel Analytics dashboard to recognize the integration and start collecting data.

## Impact
- No visual changes
- Vercel Analytics dashboard activates on next deploy
- Page view tracking begins immediately after merge